### PR TITLE
fix: use the actual icon

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,7 +27,7 @@
         <Pack>True</Pack>
         <PackagePath>\</PackagePath>
       </None>
-      <None Include="..\websocket-sharp_logo.png">
+      <None Include="..\websocket-sharp_icon.png">
         <Pack>True</Pack>
         <PackagePath>\</PackagePath>
       </None>


### PR DESCRIPTION
logo has text and is not square